### PR TITLE
Port Rails 6 time fix

### DIFF
--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -232,6 +232,7 @@ OUTPUT
         $stop_que_executable = false
         %w[INT TERM].each { |signal| trap(signal) { $stop_que_executable = true } }
 
+        output.puts "Que started with #{locker.workers.length} workers (priorities: #{locker.workers.map(&:priority)})"
         output.puts "Que waiting for jobs..."
 
         loop do

--- a/bin/command_line_interface.spec.rb
+++ b/bin/command_line_interface.spec.rb
@@ -147,6 +147,7 @@ MSG
 
       assert_equal(
         [
+          "Que started with 6 workers (priorities: [10, 30, 50, nil, nil, nil])",
           "Que waiting for jobs...",
           "\nFinishing Que's current jobs before exiting...",
           "Que's jobs finished, exiting...",

--- a/lib/que/active_record/model.rb
+++ b/lib/que/active_record/model.rb
@@ -25,9 +25,10 @@ module Que
       class << self
         def by_job_class(job_class)
           job_class = job_class.name if job_class.is_a?(Class)
+          job_class_doc = "[{\"job_class\": \"#{job_class}\"}]"
           where(
-            "que_jobs.job_class = ? OR (que_jobs.job_class = 'ActiveJob::QueueAdapters::QueAdapter::JobWrapper' AND que_jobs.args->0->>'job_class' = ?)",
-            job_class, job_class,
+            "que_jobs.job_class = ? OR (que_jobs.job_class = 'ActiveJob::QueueAdapters::QueAdapter::JobWrapper' AND que_jobs.args @> ?)",
+            job_class, job_class_doc,
           )
         end
 

--- a/lib/que/connection.rb
+++ b/lib/que/connection.rb
@@ -152,7 +152,13 @@ module Que
       },
 
       # Timestamp with time zone
-      1184 => Time.method(:parse),
+      1184 => -> (value) {
+        case value
+        when Time then value
+        when String then Time.parse(value)
+        else raise "Unexpected time class: #{value.class} (#{value.inspect})"
+        end
+      }
     }
 
     # JSON, JSONB

--- a/lib/que/job.rb
+++ b/lib/que/job.rb
@@ -17,7 +17,7 @@ module Que
         (
           coalesce($1, 'default')::text,
           coalesce($2, 100)::smallint,
-          coalesce($3, now())::timestamptz,
+          greatest($3, now())::timestamptz,
           $4::text,
           coalesce($5, '[]')::jsonb,
           coalesce($6, '{}')::jsonb


### PR DESCRIPTION
In Rails 6 we get `no implicit conversion of Time into String` when enqueueing jobs. This was patched upstream, see [here](https://github.com/que-rb/que/issues/247).