### PR TITLE
Allow que to be started with no listen/notify usage 

### DIFF
--- a/bin/command_line_interface.rb
+++ b/bin/command_line_interface.rb
@@ -51,6 +51,14 @@ module Que
             end
 
             opts.on(
+              '--listen [LISTEN]',
+              String,
+              "Set to false to only poll for new jobs"
+            ) do |listen|
+              options[:listen] = listen != "false"
+            end
+
+            opts.on(
               '-l',
               '--log-level [LEVEL]',
               String,


### PR DESCRIPTION
Resulting in jobs being picked up purely from polling

We have seen issues with listen/notify usage at scale, need to test if
polling only improves the situation.